### PR TITLE
Removed a link to search.js in the songsearch.handlebars because we a…

### DIFF
--- a/views/songsearch.handlebars
+++ b/views/songsearch.handlebars
@@ -75,4 +75,3 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
     crossorigin="anonymous"></script>
-<script src="js/search.js"></script>


### PR DESCRIPTION
…lready have search.js linked on evry page via the main handlebar.